### PR TITLE
Check that extension is enabled before showing baby head

### DIFF
--- a/js/ChromeStorageHelper.js
+++ b/js/ChromeStorageHelper.js
@@ -35,3 +35,18 @@ ChromeStorageHelper.setItems = function (data, callback) {
     chrome.storage.sync.remove('imageUrl');
     chrome.storage.sync.set(data, callback);
 };
+
+/**
+ * Simple check to verify if the extension is enabled.
+ * Performs a chrome.storage.local.get that will throw an exception if the extension is
+ * disabled or uninstalled.
+ * @returns {boolean} true if the extension is enabled, false otherwise
+ */
+ChromeStorageHelper.isExtensionEnabled = function () {
+    try {
+        chrome.storage.local.get({}, function (){});
+        return true;
+    } catch (e) {
+        return false;
+    }
+};

--- a/js/FBH.js
+++ b/js/FBH.js
@@ -44,20 +44,20 @@ FBH.prototype = {
 
         $(document.body).keypress(function (event) {
             if (event.ctrlKey && event.shiftKey && event.which === 6) {
-                me.showBabyHead();
+                me.triggerBabyHead();
             }
         });
         me.setBabyHeadTimeout();
     },
 
-    showBabyHead: function () {
+    triggerBabyHead: function () {
         var me = this;
 
         clearTimeout(me.nextAppearanceTimeoutId);
         me.nextAppearanceTimeoutId = null;
 
         // Only allow one image at a time
-        if (me.activeImageExists()) {
+        if (me.activeImageExists() || !ChromeStorageHelper.isExtensionEnabled()) {
             return false;
         }
 
@@ -142,7 +142,7 @@ FBH.prototype = {
         me.nextAppearanceTimeoutId = setTimeout(
             function () {
                 me.nextAppearanceTimeoutId = null;
-                me.showBabyHead();
+                me.triggerBabyHead();
             },
             me.getTimeout()
         );


### PR DESCRIPTION
Added a check to verify that the extension is enabled before showing the baby head.
This should prevent complaints from people saying they've uninstalled the extension but the baby head is still appearing.